### PR TITLE
Upgrade file upload middleware

### DIFF
--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -3,6 +3,7 @@ import { ApolloServer, ForbiddenError, UserInputError } from 'apollo-server-expr
 import cors, { CorsOptions } from 'cors';
 import express from 'express';
 import session from 'express-session';
+import { graphqlUploadExpress } from 'graphql-upload';
 import path from 'path';
 import { buildSchema } from 'type-graphql';
 import { Container } from 'typedi';
@@ -40,6 +41,7 @@ const createApolloServer = async (app: express.Application, corsOptions: CorsOpt
   const server = new ApolloServer({
     schema,
     context: ctx => buildContext(ctx),
+    uploads: false,
     formatError: err => {
       if (err.message.startsWith('Access denied!')) return new ForbiddenError(err.message);
       if (err.message === 'Argument Validation Error')
@@ -81,6 +83,7 @@ export default async function getShowOnRoad(config: AppConfig) {
 
   logger.info('Configuring middleware...');
   app.use(cors(config.cors));
+  app.use(graphqlUploadExpress({ maxFileSize: 10000000, maxFiles: 10 }));
   app.use('/uploads', express.static(config.uploads.dir));
 
   createSessionMiddleware(app, config);

--- a/packages/server/src/resolvers/RecipeResolver.ts
+++ b/packages/server/src/resolvers/RecipeResolver.ts
@@ -1,6 +1,4 @@
-import { GraphQLUpload } from 'apollo-server-core';
-import { GraphQLScalarType } from 'graphql';
-import { FileUpload } from 'graphql-upload';
+import { GraphQLUpload, FileUpload } from 'graphql-upload';
 import {
   Arg,
   Authorized,
@@ -41,9 +39,9 @@ export class RecipeResolver implements ResolverInterface<Recipe> {
   }
 
   @Mutation(returns => String)
-  stageImage(
-    @Arg('file', type => GraphQLUpload as GraphQLScalarType)
-    file: FileUpload
+  async stageImage(
+    @Arg('file', type => GraphQLUpload)
+    file: Promise<FileUpload>
   ): Promise<string> {
     /**
      * This will accept a file as an argument and return something that identifies this file once it
@@ -51,7 +49,7 @@ export class RecipeResolver implements ResolverInterface<Recipe> {
      * saved to the database.
      * https://github.com/MichalLytek/type-graphql/issues/37
      */
-    const { mimetype, createReadStream } = file;
+    const { mimetype, createReadStream } = await file;
     return this.imageService.stageImage({
       mimetype,
       stream: createReadStream(),


### PR DESCRIPTION
Fixes an issue where file uploads stop working in Node 13. The version of graphql-upload bundled with apollo-server-core is incompatible. We now apply the upload middleware ourselves instead of depending on Apollo's version.

Reference and link to workaround:
https://github.com/apollographql/apollo-server/issues/3508#issuecomment-610511209